### PR TITLE
Rich types

### DIFF
--- a/examples/rich_types.tl
+++ b/examples/rich_types.tl
@@ -4,6 +4,6 @@ const int I = 123
 const bytes B = "abc"
 const bigint Bi = 1231231231231231231231231231231231 
 const bigint One = 1
-assert((Bi / Bi) == One)
+assert((Bi b/ Bi) b== One)
 
 exit(1)

--- a/examples/rich_types.tl
+++ b/examples/rich_types.tl
@@ -1,0 +1,9 @@
+#pragma version 8
+
+const int I = 123
+const bytes B = "abc"
+const bigint Bi = 1231231231231231231231231231231231 
+const bigint One = 1
+assert((Bi / Bi) == One)
+
+exit(1)

--- a/tealish/base.py
+++ b/tealish/base.py
@@ -22,16 +22,15 @@ lang_spec = get_active_langspec()
 def check_arg_types(name: str, incoming_args: List["Node"]) -> None:
     op = lang_spec.lookup_op(name)
     expected_args = op.arg_types
-    # TODO:
     for i, incoming_arg in enumerate(incoming_args):
         tealish_type = incoming_arg.tealish_type()
         avm_type = stack_type(tealish_type)
 
-        if avm_type == AVMType.any:  # type: ignore
+        if avm_type == AVMType.any:
             continue
         if expected_args[i] == AVMType.any:
             continue
-        if avm_type == expected_args[i]:  # type: ignore
+        if tealish_type == expected_args[i]:
             continue
 
         raise Exception(
@@ -172,8 +171,11 @@ class BaseNode:
 
     def tealish_type(self) -> TealishType:
         if hasattr(self, "type"):
-            return getattr(self, "type")
-        return TealishType.any
+            return cast(TealishType, getattr(self, "type"))
+        return TealishType.none
+
+    def stack_type(self) -> AVMType:
+        return stack_type(self.tealish_type())
 
     # TODO: these attributes are only available on Node and other children types
     # we should either define them here or something else?

--- a/tealish/base.py
+++ b/tealish/base.py
@@ -152,7 +152,7 @@ class BaseNode:
         except Exception as e:
             raise CompileError(str(e), node=self)  # type: ignore
 
-    def get_field_type(self, namespace: str, name: str) -> AVMType:
+    def get_field_type(self, namespace: str, name: str) -> TealishType:
         return lang_spec.get_field_type(namespace, name)
 
     def lookup_op(self, name: str) -> Op:
@@ -164,18 +164,16 @@ class BaseNode:
     def lookup_var(self, name: str) -> Any:
         return self.get_scope().lookup_var(name)
 
-    def lookup_const(self, name: str) -> Tuple["AVMType", ConstValue]:
+    def lookup_const(self, name: str) -> Tuple["TealishType", ConstValue]:
         return self.get_scope().lookup_const(name)
 
-    def lookup_avm_constant(self, name: str) -> Tuple["AVMType", Any]:
+    def lookup_avm_constant(self, name: str) -> Tuple["TealishType", Any]:
         return lang_spec.lookup_avm_constant(name)
 
     def tealish_type(self) -> TealishType:
         if hasattr(self, "type"):
             return getattr(self, "type")
-        print(self.__class__)
-        # TODO: cop out
-        return TealishType.int
+        return TealishType.any
 
     # TODO: these attributes are only available on Node and other children types
     # we should either define them here or something else?

--- a/tealish/base.py
+++ b/tealish/base.py
@@ -1,6 +1,6 @@
 from typing import cast, Any, Dict, List, Optional, Tuple, TYPE_CHECKING
 from tealish.errors import CompileError
-from .tealish_builtins import AVMType, ConstValue, ScratchRecord, VarType
+from .tealish_builtins import AVMType, ConstValue, ScratchRecord, VarType, TealishType
 from .langspec import get_active_langspec, Op
 from .scope import Scope
 
@@ -159,6 +159,13 @@ class BaseNode:
 
     def lookup_avm_constant(self, name: str) -> Tuple["AVMType", Any]:
         return lang_spec.lookup_avm_constant(name)
+
+    def tealish_type(self) -> TealishType:
+        if hasattr(self, "t_type"):
+            return getattr(self, "t_type")
+        print(self.__class__)
+        # TODO: cop out
+        return TealishType.int
 
     # TODO: these attributes are only available on Node and other children types
     # we should either define them here or something else?

--- a/tealish/expression_nodes.py
+++ b/tealish/expression_nodes.py
@@ -49,7 +49,7 @@ class Variable(BaseNode):
             raise CompileError(e.args[0], node=self)
         # is it a struct or box?
         if type(self.type) == tuple:
-            if self.type[0] == ObjectType.struct:
+            if self.type[0] == ObjectType.scratch:
                 self.type = AVMType.bytes
             elif self.type[0] == ObjectType.box:
                 raise CompileError("Invalid use of a Box reference", node=self)
@@ -479,7 +479,7 @@ class StructOrBoxField(BaseNode):
         self.type = struct_field.data_type
 
     def write_teal(self, writer: "TealWriter") -> None:
-        if self.object_type == ObjectType.struct:
+        if self.object_type == ObjectType.scratch:
             writer.write(self, f"load {self.slot} // {self.name}")
             if self.type == AVMType.int:
                 writer.write(self, f"pushint {self.offset}")

--- a/tealish/expression_nodes.py
+++ b/tealish/expression_nodes.py
@@ -137,14 +137,18 @@ class BinaryOp(BaseNode):
         self.a.process()
         self.b.process()
 
-        print(self.a.tealish_type())
+        # Make sure they're the same type we're trying to binop
+        assert self.a.tealish_type() == self.b.tealish_type()
+
         if self.a.tealish_type() == TealishType.bigint.value:
+            # TODO: remap op based on TealishType
+            # for bigint, / => b/, * => b*, ...
+            # for string, + => concat
+            # lazy punt is prepend b for bigints
             self.op = "b" + self.op
-            self.type = TealishType.bigint
 
         self.check_arg_types(self.op, [self.a, self.b])
         op = self.lookup_op(self.op)
-
         self.type = type_lookup(op.returns)
         if (
             self.a.tealish_type() == TealishType.bigint.value

--- a/tealish/expression_nodes.py
+++ b/tealish/expression_nodes.py
@@ -86,8 +86,8 @@ class Constant(BaseNode):
                 raise CompileError(
                     f'Constant "{self.name}" not declared in scope', node=self
                 )
-        # if type not in (AVMType.int, AVMType.bytes):
-        #    raise CompileError(f"Unexpected const type {type}", node=self)
+        if stack_type(type) not in (AVMType.int, AVMType.bytes):
+            raise CompileError(f"Unexpected const type {type}", node=self)
 
         self.type = type
         self.value = value

--- a/tealish/expression_nodes.py
+++ b/tealish/expression_nodes.py
@@ -137,8 +137,8 @@ class BinaryOp(BaseNode):
         self.a.process()
         self.b.process()
 
-        # Make sure they're the same type we're trying to binop
-        assert self.a.tealish_type() == self.b.tealish_type()
+        # TODO: Make sure they're the same type we're trying to binop
+        # assert self.a.tealish_type() == self.b.tealish_type()
 
         if self.a.tealish_type() == TealishType.bigint.value:
             # TODO: remap op based on TealishType

--- a/tealish/expression_nodes.py
+++ b/tealish/expression_nodes.py
@@ -137,13 +137,20 @@ class BinaryOp(BaseNode):
         self.a.process()
         self.b.process()
 
-        if self.a.tealish_type() == TealishType.bigint:
-            self.t_type = TealishType.bigint
+        print(self.a.tealish_type())
+        if self.a.tealish_type() == TealishType.bigint.value:
             self.op = "b" + self.op
+            self.type = TealishType.bigint
 
         self.check_arg_types(self.op, [self.a, self.b])
         op = self.lookup_op(self.op)
+
         self.type = type_lookup(op.returns)
+        if (
+            self.a.tealish_type() == TealishType.bigint.value
+            and self.type == TealishType.bytes
+        ):
+            self.type = TealishType.bigint
 
     def write_teal(self, writer: "TealWriter") -> None:
         writer.write(self, self.a)
@@ -164,8 +171,7 @@ class Group(BaseNode):
 
     def process(self) -> None:
         self.expression.process()
-        self.type = self.expression.type
-        self.t_type = self.expression.tealish_type()
+        self.type = self.expression.tealish_type()
 
     def write_teal(self, writer: "TealWriter") -> None:
         writer.write(self, self.expression)

--- a/tealish/expression_nodes.py
+++ b/tealish/expression_nodes.py
@@ -136,25 +136,9 @@ class BinaryOp(BaseNode):
     def process(self) -> None:
         self.a.process()
         self.b.process()
-
-        # TODO: Make sure they're the same type we're trying to binop
-        # assert self.a.tealish_type() == self.b.tealish_type()
-
-        if self.a.tealish_type() == TealishType.bigint.value:
-            # TODO: remap op based on TealishType
-            # for bigint, / => b/, * => b*, ...
-            # for string, + => concat
-            # lazy punt is prepend b for bigints
-            self.op = "b" + self.op
-
         self.check_arg_types(self.op, [self.a, self.b])
         op = self.lookup_op(self.op)
         self.type = type_lookup(op.returns)
-        if (
-            self.a.tealish_type() == TealishType.bigint.value
-            and self.type == TealishType.bytes
-        ):
-            self.type = TealishType.bigint
 
     def write_teal(self, writer: "TealWriter") -> None:
         writer.write(self, self.a)

--- a/tealish/langspec.py
+++ b/tealish/langspec.py
@@ -3,25 +3,25 @@ import os
 import requests
 import tealish
 import json
-from .tealish_builtins import constants, AVMType
+from .tealish_builtins import constants, TealishType
 from typing import List, Dict, Any, Tuple, Optional
 
 abc = "ABCDEFGHIJK"
 
 
 _opcode_type_map = {
-    ".": AVMType.any,
-    "B": AVMType.bytes,
-    "U": AVMType.int,
-    "": AVMType.none,
+    ".": TealishType.any,
+    "B": TealishType.bytes,
+    "U": TealishType.int,
+    "": TealishType.none,
 }
 
 
-def type_lookup(a: str) -> AVMType:
+def type_lookup(a: str) -> TealishType:
     return _opcode_type_map[a]
 
 
-def convert_args_to_types(args: str) -> List[AVMType]:
+def convert_args_to_types(args: str) -> List[TealishType]:
     return [type_lookup(args[idx]) for idx in range(len(args))]
 
 
@@ -35,11 +35,11 @@ class Op:
     #: list of arg types this op takes off the stack, encoded as a string
     args: str
     #: decoded list of incoming args
-    arg_types: List[AVMType]
+    arg_types: List[TealishType]
     #: list of arg types this op puts on the stack, encoded as a string
     returns: str
     #: decoded list of outgoing args
-    returns_types: List[AVMType]
+    returns_types: List[TealishType]
     #: how many bytes this opcode takes up when assembled
     size: int
     #: describes the args to be passed as immediate arguments to this op
@@ -47,9 +47,9 @@ class Op:
     #: describes the list of names that can be used as immediate arguments
     arg_enum: List[str]
     #: describes the types returned when each arg enum is used
-    arg_enum_types: List[AVMType]
+    arg_enum_types: List[TealishType]
     #: dictionary mapping the names in arg_enum to types in arg_enum_types
-    arg_enum_dict: Dict[str, AVMType]
+    arg_enum_dict: Dict[str, TealishType]
 
     #: informational string about the op
     doc: str
@@ -91,7 +91,7 @@ class Op:
             if "ArgEnumTypes" in op_def:
                 self.arg_enum_types = convert_args_to_types(op_def["ArgEnumTypes"])
             else:
-                self.arg_enum_types = [AVMType.int] * len(self.arg_enum)
+                self.arg_enum_types = [TealishType.int] * len(self.arg_enum)
             self.arg_enum_dict = dict(zip(self.arg_enum, self.arg_enum_types))
         else:
             self.arg_enum = []
@@ -126,8 +126,8 @@ class LangSpec:
             "Txn": self.ops["txn"].arg_enum_dict,
         }
 
-        self.global_fields: Dict[str, AVMType] = self.fields["Global"]
-        self.txn_fields: Dict[str, AVMType] = self.fields["Txn"]
+        self.global_fields: Dict[str, TealishType] = self.fields["Global"]
+        self.txn_fields: Dict[str, TealishType] = self.fields["Txn"]
 
     def as_dict(self) -> Dict[str, Any]:
         return self.spec
@@ -141,12 +141,12 @@ class LangSpec:
             raise KeyError(f'Op "{name}" does not exist!')
         return self.ops[name]
 
-    def lookup_avm_constant(self, name: str) -> Tuple[AVMType, Any]:
+    def lookup_avm_constant(self, name: str) -> Tuple[TealishType, Any]:
         if name not in constants:
             raise KeyError(f'Constant "{name}" does not exist!')
         return constants[name]
 
-    def get_field_type(self, namespace: str, name: str) -> AVMType:
+    def get_field_type(self, namespace: str, name: str) -> TealishType:
         if "txn" in namespace:
             return self.txn_fields[name]
         elif namespace == "global":

--- a/tealish/nodes.py
+++ b/tealish/nodes.py
@@ -23,6 +23,7 @@ from .tealish_builtins import (
     VarType,
     Struct,
     StructField,
+    stack_type,
 )
 from .scope import Scope
 
@@ -159,8 +160,8 @@ class LiteralInt(Literal):
     def write_teal(self, writer: "TealWriter") -> None:
         writer.write(self, f"pushint {self.value}")
 
-    def type(self) -> AVMType:
-        return AVMType.int
+    def type(self) -> TealishType:
+        return TealishType.int
 
     def _tealish(self) -> str:
         return f"{self.value}"
@@ -173,8 +174,8 @@ class LiteralBytes(Literal):
     def write_teal(self, writer: "TealWriter") -> None:
         writer.write(self, f"pushbytes {self.value}")
 
-    def type(self) -> AVMType:
-        return AVMType.bytes
+    def type(self) -> TealishType:
+        return TealishType.bytes
 
     def _tealish(self) -> str:
         return f"{self.value}"
@@ -378,33 +379,29 @@ class Const(LineStatement):
     print(type_pattern)
 
     pattern = (
-        rf"const (?P<t_type>{type_pattern}) "
+        rf"const (?P<type>{type_pattern}) "
         + r"(?P<name>[A-Z][a-zA-Z0-9_]*) = (?P<expression>.*)$"
     )
-    t_type: TealishType
-    type: AVMType
+    type: TealishType
     name: str
     expression: Literal
 
     def process(self) -> None:
         scope = self.get_current_scope()
-        self.type = (
-            AVMType.bytes if self.t_type != TealishType.int.value else AVMType.int
-        )
 
         # TODO: have to compare against Enum.value ?
-        if self.t_type == TealishType.bigint.value:
+        if self.type == TealishType.bigint.value:
             # Hardcoded to uint256 or 32 bytes
             new_value = cast(int, int(self.expression.value)).to_bytes(32, "big")
             self.expression.value = f"0x{new_value.hex()}"
 
-        scope.declare_const(self.name, (self.t_type, self.expression.value))
+        scope.declare_const(self.name, (self.type, self.expression.value))
 
     def write_teal(self, writer: "TealWriter") -> None:
         pass
 
     def _tealish(self) -> str:
-        s = f"const {self.t_type} {self.name}"
+        s = f"const {self.type} {self.name}"
         if self.expression:
             s += f" = {self.expression.tealish()}"
         return s + "\n"
@@ -470,7 +467,7 @@ class Assert(LineStatement):
 
     def process(self) -> None:
         self.arg.process()
-        if self.arg.type not in (AVMType.int, AVMType.any):
+        if stack_type(self.arg.type) not in (AVMType.int, AVMType.any):
             raise CompileError(
                 "Incorrect type for assert. "
                 + f"Expected int, got {self.arg.type} at line {self.line_no}.",
@@ -501,10 +498,10 @@ class BytesDeclaration(LineStatement):
     expression: GenericExpression
 
     def process(self) -> None:
-        self.name.slot = self.declare_var(self.name.value, AVMType.bytes)
+        self.name.slot = self.declare_var(self.name.value, TealishType.bytes)
         if self.expression:
             self.expression.process()
-            if self.expression.type not in (AVMType.bytes, AVMType.any):
+            if stack_type(self.expression.type) not in (AVMType.bytes, AVMType.any):
                 raise CompileError(
                     "Incorrect type for bytes assignment. "
                     + f"Expected bytes, got {self.expression.type}",
@@ -530,10 +527,10 @@ class IntDeclaration(LineStatement):
     expression: GenericExpression
 
     def process(self) -> None:
-        self.name.slot = self.declare_var(self.name.value, AVMType.int)
+        self.name.slot = self.declare_var(self.name.value, TealishType.int)
         if self.expression:
             self.expression.process()
-            if self.expression.type not in (AVMType.int, AVMType.any):
+            if stack_type(self.expression.type) not in (AVMType.int, AVMType.any):
                 raise CompileError(
                     "Incorrect type for int assignment. "
                     + f"Expected int, got {self.expression.type}",
@@ -584,7 +581,10 @@ class Assignment(LineStatement):
                 )
 
             slot, var_type = var_def
-            if not (incoming_types[i] == AVMType.any or incoming_types[i] == var_type):
+            if not (
+                stack_type(incoming_types[i]) == AVMType.any
+                or stack_type(incoming_types[i]) == var_type
+            ):
                 raise CompileError(
                     f"Incorrect type for {var_type} assignment. "
                     + f"Expected {var_type}, got {incoming_types[i]}",
@@ -1292,7 +1292,7 @@ class ForStatement(InlineStatement):
         return node
 
     def process(self) -> None:
-        self.var_slot = self.declare_var(self.var, AVMType.int)
+        self.var_slot = self.declare_var(self.var, TealishType.int)
         for n in self.nodes:
             n.process()
         self.del_var(self.var)
@@ -1388,7 +1388,7 @@ class For_Statement(InlineStatement):
 class ArgsList(Expression):
     arg_pattern = r"(?P<arg_name>[a-z][a-z_0-9]*): (?P<arg_type>int|bytes)"
     pattern = rf"(?P<args>({arg_pattern}(, )?)*)"
-    args: List[Tuple[str, AVMType]]
+    args: List[Tuple[str, TealishType]]
 
     def __init__(self, line: str) -> None:
         super().__init__(line)
@@ -1406,7 +1406,7 @@ class Func(InlineStatement):
     args: ArgsList
 
     return_type: str
-    returns: List[AVMType]
+    returns: List[TealishType]
 
     def __init__(
         self,
@@ -1421,7 +1421,8 @@ class Func(InlineStatement):
         self.new_scope("func__" + self.name)
         self.returns = list(
             filter(
-                None, [cast(AVMType, s.strip()) for s in self.return_type.split(",")]
+                None,
+                [cast(TealishType, s.strip()) for s in self.return_type.split(",")],
             )
         )
         self.slots: Dict[str, int] = {}
@@ -1516,7 +1517,7 @@ class StructFieldDefinition(InlineStatement):
         + r"(?P<data_type>[a-z][A-Z-a-z0-9_]+)(\[(?P<data_length>\d+)\])?"
     )
     field_name: str
-    data_type: AVMType
+    data_type: TealishType
     data_length: int
     offset: int
 
@@ -1590,7 +1591,7 @@ class StructDefinition(InlineStatement):
                 data_length=field_node.data_length,
                 offset=offset,
                 size=8
-                if field_node.data_type == AVMType.int
+                if stack_type(field_node.data_type) == AVMType.int
                 else int(field_node.data_length),
             )
             fields[field_node.field_name] = sf
@@ -1627,7 +1628,7 @@ class StructDeclaration(LineStatement):
         )
         if self.expression:
             self.expression.process()
-            if self.expression.type not in (AVMType.bytes, AVMType.any):
+            if stack_type(self.expression.type) not in (AVMType.bytes, AVMType.any):
                 raise CompileError(
                     "Incorrect type for struct assignment. "
                     + f"Expected bytes, got {self.expression.type}",
@@ -1672,9 +1673,9 @@ class StructOrBoxAssignment(LineStatement):
         struct_field = struct.fields[self.field_name]
         self.offset = struct_field.offset
         self.size = struct_field.size
-        self.data_type = struct_field.data_type
+        self.data_type = stack_type(struct_field.data_type)
         self.expression.process()
-        if self.expression.type not in (self.data_type, AVMType.any):
+        if stack_type(self.expression.type) not in (self.data_type, AVMType.any):
             raise CompileError(
                 "Incorrect type for struct field assignment. "
                 + f"Expected {self.data_type}, got {self.expression.type}",
@@ -1686,7 +1687,7 @@ class StructOrBoxAssignment(LineStatement):
             writer.write(self, f"// {self.line} [slot {self.name.slot}]")
             writer.write(self, f"load {self.name.slot} // {self.name.value}")
             writer.write(self, self.expression)
-            if self.data_type == AVMType.int:
+            if stack_type(self.data_type) == AVMType.int:
                 writer.write(self, "itob")
             writer.write(
                 self, f"replace {self.offset} // {self.name.value}.{self.field_name}"
@@ -1697,7 +1698,7 @@ class StructOrBoxAssignment(LineStatement):
             writer.write(self, f"load {self.name.slot} // box key {self.name.value}")
             writer.write(self, f"pushint {self.offset} // offset")
             writer.write(self, self.expression)
-            if self.data_type == AVMType.int:
+            if stack_type(self.data_type) == AVMType.int:
                 writer.write(self, "itob")
             writer.write(self, f"box_replace // {self.name.value}.{self.field_name}")
 
@@ -1732,7 +1733,7 @@ class BoxDeclaration(LineStatement):
             self.name.value, (ObjectType.box, self.struct_name)
         )
         self.key.process()
-        if self.key.type not in (AVMType.bytes, AVMType.any):
+        if stack_type(self.key.type) not in (AVMType.bytes, AVMType.any):
             raise CompileError(
                 f"Incorrect type for box key. Expected bytes, got {self.key.type}",
                 node=self,

--- a/tealish/nodes.py
+++ b/tealish/nodes.py
@@ -464,8 +464,7 @@ class Assert(LineStatement):
 
     def process(self) -> None:
         self.arg.process()
-        print(self.arg.type)
-        print(stack_type(self.arg.type))
+
         if stack_type(self.arg.type) not in (AVMType.int, AVMType.any):
             raise CompileError(
                 "Incorrect type for assert. "

--- a/tealish/nodes.py
+++ b/tealish/nodes.py
@@ -160,9 +160,6 @@ class LiteralInt(Literal):
     def write_teal(self, writer: "TealWriter") -> None:
         writer.write(self, f"pushint {self.value}")
 
-    def type(self) -> TealishType:
-        return TealishType.int
-
     def _tealish(self) -> str:
         return f"{self.value}"
 
@@ -173,9 +170,6 @@ class LiteralBytes(Literal):
 
     def write_teal(self, writer: "TealWriter") -> None:
         writer.write(self, f"pushbytes {self.value}")
-
-    def type(self) -> TealishType:
-        return TealishType.bytes
 
     def _tealish(self) -> str:
         return f"{self.value}"
@@ -192,9 +186,6 @@ class Name(Expression):
 
     def _tealish(self) -> str:
         return f"{self.value}"
-
-    def type(self) -> Optional[VarType]:
-        return self._type
 
 
 class GenericExpression(Expression):

--- a/tealish/nodes.py
+++ b/tealish/nodes.py
@@ -1608,7 +1608,7 @@ class StructDeclaration(LineStatement):
 
     def process(self) -> None:
         self.name.slot = self.declare_var(
-            self.name.value, (ObjectType.struct, self.struct_name)
+            self.name.value, (ObjectType.scratch, self.struct_name)
         )
         if self.expression:
             self.expression.process()
@@ -1667,7 +1667,7 @@ class StructOrBoxAssignment(LineStatement):
             )
 
     def write_teal(self, writer: "TealWriter") -> None:
-        if self.object_type == ObjectType.struct:
+        if self.object_type == ObjectType.scratch:
             writer.write(self, f"// {self.line} [slot {self.name.slot}]")
             writer.write(self, f"load {self.name.slot} // {self.name.value}")
             writer.write(self, self.expression)

--- a/tealish/scope.py
+++ b/tealish/scope.py
@@ -1,9 +1,8 @@
-from typing import Dict, Optional, Tuple, TYPE_CHECKING, Union
+from typing import Dict, Optional, Tuple, TYPE_CHECKING
 
 
 if TYPE_CHECKING:
     from .tealish_builtins import (
-        AVMType,
         VarType,
         ConstValue,
         ScratchRecord,
@@ -27,7 +26,7 @@ class Scope:
             slot_range if slot_range is not None else (0, 200)
         )
 
-        self.consts: Dict[str, Tuple["AVMType", "ConstValue"]] = {}
+        self.consts: Dict[str, Tuple["TealishType", "ConstValue"]] = {}
         self.blocks: Dict[str, "Block"] = {}
         self.functions: Dict[str, "Func"] = {}
 

--- a/tealish/scope.py
+++ b/tealish/scope.py
@@ -1,8 +1,14 @@
-from typing import Dict, Optional, Tuple, TYPE_CHECKING
+from typing import Dict, Optional, Tuple, TYPE_CHECKING, Union
 
 
 if TYPE_CHECKING:
-    from .tealish_builtins import AVMType, VarType, ConstValue, ScratchRecord
+    from .tealish_builtins import (
+        AVMType,
+        VarType,
+        ConstValue,
+        ScratchRecord,
+        TealishType,
+    )
     from .nodes import Func, Block
 
 
@@ -59,11 +65,13 @@ class Scope:
             del self.slots[name]
 
     def declare_const(
-        self, name: str, const_data: Tuple["AVMType", "ConstValue"]
+        self,
+        name: str,
+        const_data: Tuple["TealishType", "ConstValue"],
     ) -> None:
         self.consts[name] = const_data
 
-    def lookup_const(self, name: str) -> Tuple["AVMType", "ConstValue"]:
+    def lookup_const(self, name: str) -> Tuple["TealishType", "ConstValue"]:
         if name not in self.consts:
             raise KeyError(f'Const "{name}" not declared in current scope')
         return self.consts[name]

--- a/tealish/tealish_builtins.py
+++ b/tealish/tealish_builtins.py
@@ -12,17 +12,26 @@ class AVMType(str, Enum):
     none = ""
 
 
-# TODO: add frame ptr or stack? rename to something like `storage type?`
-# I think `struct` here should probably just be `scratch`?
 class ObjectType(str, Enum):
     """ObjectType determines where to get the bytes for a struct field.
 
-    `struct` - the field is in a byte array in a scratch var, use extract to get bytes
+    `scratch` - the field is in a byte array in a scratch var, use extract to get bytes
     `box` - the field is in a box, use box_extract to get the bytes
     """
 
     scratch = "scratch"
     box = "box"
+
+
+class TealishType(str, Enum):
+    int = "int"
+    bytes = "bytes"
+    bigint = "bigint"
+    addr = "addr"
+
+
+def tealish_to_avm_type(tt: TealishType) -> AVMType:
+    return AVMType.bytes if tt != TealishType.int.value else AVMType.int
 
 
 # TODO: for CustomType and ScratchRecord we should consider

--- a/tealish/tealish_builtins.py
+++ b/tealish/tealish_builtins.py
@@ -21,7 +21,7 @@ class ObjectType(str, Enum):
     `box` - the field is in a box, use box_extract to get the bytes
     """
 
-    struct = "struct"
+    scratch = "scratch"
     box = "box"
 
 

--- a/tealish/tealish_builtins.py
+++ b/tealish/tealish_builtins.py
@@ -24,12 +24,15 @@ class ObjectType(str, Enum):
 
 
 class TealishType(str, Enum):
-    int = "int"
+    # Mirrors AVM Types
+    any = "any"
     bytes = "bytes"
+    int = "int"
+    none = ""
+
+    # New types for tealish
     bigint = "bigint"
     addr = "addr"
-    any = "any"
-    none = ""
 
 
 def stack_type(tt: TealishType) -> AVMType:

--- a/tealish/tealish_builtins.py
+++ b/tealish/tealish_builtins.py
@@ -28,10 +28,19 @@ class TealishType(str, Enum):
     bytes = "bytes"
     bigint = "bigint"
     addr = "addr"
+    any = "any"
+    none = ""
 
 
-def tealish_to_avm_type(tt: TealishType) -> AVMType:
-    return AVMType.bytes if tt != TealishType.int.value else AVMType.int
+def stack_type(tt: TealishType) -> AVMType:
+    if tt == TealishType.int.value:
+        return AVMType.int
+    elif tt == TealishType.none:
+        return AVMType.none
+    elif tt == TealishType.any:
+        return AVMType.any
+    else:
+        return AVMType.bytes
 
 
 # TODO: for CustomType and ScratchRecord we should consider
@@ -45,7 +54,7 @@ CustomType = Tuple[ObjectType, str]
 
 @dataclass
 class StructField:
-    data_type: AVMType
+    data_type: TealishType
     data_length: int
     offset: int
     size: int
@@ -63,7 +72,7 @@ class Struct:
 
 
 # either AVM native type or a CustomType (only struct atm) definition
-VarType = Union[AVMType, CustomType]
+VarType = Union[TealishType, CustomType]
 
 # a constant value introduced in source
 ConstValue = Union[str, bytes, int]
@@ -83,16 +92,16 @@ def get_struct(struct_name: str) -> Struct:
     return _structs[struct_name]
 
 
-constants: Dict[str, Tuple[AVMType, ConstValue]] = {
-    "NoOp": (AVMType.int, 0),
-    "OptIn": (AVMType.int, 1),
-    "CloseOut": (AVMType.int, 2),
-    "ClearState": (AVMType.int, 3),
-    "UpdateApplication": (AVMType.int, 4),
-    "DeleteApplication": (AVMType.int, 5),
-    "Pay": (AVMType.int, 1),
-    "Acfg": (AVMType.int, 3),
-    "Axfer": (AVMType.int, 4),
-    "Afrz": (AVMType.int, 5),
-    "Appl": (AVMType.int, 6),
+constants: Dict[str, Tuple[TealishType, ConstValue]] = {
+    "NoOp": (TealishType.int, 0),
+    "OptIn": (TealishType.int, 1),
+    "CloseOut": (TealishType.int, 2),
+    "ClearState": (TealishType.int, 3),
+    "UpdateApplication": (TealishType.int, 4),
+    "DeleteApplication": (TealishType.int, 5),
+    "Pay": (TealishType.int, 1),
+    "Acfg": (TealishType.int, 3),
+    "Axfer": (TealishType.int, 4),
+    "Afrz": (TealishType.int, 5),
+    "Appl": (TealishType.int, 6),
 }


### PR DESCRIPTION
**In this PR:**

Defined a new type enum `TealishType` that is a superset of AVM types.

Replaced AVMType as the type on the nodes `type` attribute for `TealishType`.

Use `stack_value` to convert to AVM type wherever necessary

Hacky remap of binop op if we see that either operands are `bigint`

---
**Notes**

`TealishType` should probably be reworked to include other metadata about the type itself (for addr, length of 32 bytes)

Other `TealishTypes` to consider:

  `addr` - `byte[32]`
  `string` - literally just `bytes`, dont overthink it
  `uintN` - if we need to pack a list of bigints, we'd need to have the exact length in bytes for striding
  `bool`  - an uint64 with special encoding rules IF necessary
  `tuple` - can only be used with sized elements, basically a struct with no names
  `vec/list/array` - must use static sized types

The `langspec` should map ops and fields to `TealishType` ops:

for bigint
```
/,+,-,*, == -> b/, b+, b-, b*, b==
```

for addr, any txn field that returns an address could be marked as returning an `addr` type. 

---
 
**Example**
the Tealish:
```
#pragma version 8
const bigint Bi = 1231231231231231231231231231231231 
const bigint One = 1
assert((Bi / Bi) == One)

exit(1)
```

generates:
```
#pragma version 8

// assert((Bi / Bi) == One)
pushbytes 0x0000000000000000000000000000000000003cb452ac0b552af8d407b31f84ff // Bi
pushbytes 0x0000000000000000000000000000000000003cb452ac0b552af8d407b31f84ff // Bi
b/
pushbytes 0x0000000000000000000000000000000000000000000000000000000000000001 // One
b==
assert

// exit(1)
pushint 1
return
```

